### PR TITLE
feat: add useLocalStorageState hook

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -2081,4 +2081,29 @@ function useValidate(data = {}, constraints = {}, { onError = noop, onSuccess = 
     return { ...state, validate: perform };
 }
 
-export { useDebounce, useFormState, useOnClickOutside, useOnScroll, useStep, useThrottle, useToggle, useValidate };
+function useLocalStorageState(key, defaultValue = '', { serialize = JSON.stringify, deserialize = JSON.parse } = {}) {
+    const [state, setState] = useState(() => {
+        const valueInLocalStorage = window.localStorage.getItem(key);
+        if (valueInLocalStorage) {
+            try {
+                return deserialize(valueInLocalStorage);
+            }
+            catch {
+                window.localStorage.removeItem(key);
+            }
+        }
+        return typeof defaultValue === 'function' ? defaultValue() : defaultValue;
+    });
+    const prevKeyRef = useRef(key);
+    useEffect(() => {
+        const prevKey = prevKeyRef.current;
+        if (prevKey !== key) {
+            window.localStorage.removeItem(prevKey);
+        }
+        prevKeyRef.current = key;
+        window.localStorage.setItem(key, serialize(state));
+    }, [key, state, serialize]);
+    return [state, setState];
+}
+
+export { useDebounce, useFormState, useLocalStorageState, useOnClickOutside, useOnScroll, useStep, useThrottle, useToggle, useValidate };

--- a/dist/index.js
+++ b/dist/index.js
@@ -2090,8 +2090,34 @@ function useValidate(data = {}, constraints = {}, { onError = noop, onSuccess = 
     return { ...state, validate: perform };
 }
 
+function useLocalStorageState(key, defaultValue = '', { serialize = JSON.stringify, deserialize = JSON.parse } = {}) {
+    const [state, setState] = react.useState(() => {
+        const valueInLocalStorage = window.localStorage.getItem(key);
+        if (valueInLocalStorage) {
+            try {
+                return deserialize(valueInLocalStorage);
+            }
+            catch {
+                window.localStorage.removeItem(key);
+            }
+        }
+        return typeof defaultValue === 'function' ? defaultValue() : defaultValue;
+    });
+    const prevKeyRef = react.useRef(key);
+    react.useEffect(() => {
+        const prevKey = prevKeyRef.current;
+        if (prevKey !== key) {
+            window.localStorage.removeItem(prevKey);
+        }
+        prevKeyRef.current = key;
+        window.localStorage.setItem(key, serialize(state));
+    }, [key, state, serialize]);
+    return [state, setState];
+}
+
 exports.useDebounce = useDebounce;
 exports.useFormState = useFormState;
+exports.useLocalStorageState = useLocalStorageState;
 exports.useOnClickOutside = useOnClickOutside;
 exports.useOnScroll = useOnScroll;
 exports.useStep = useStep;

--- a/dist/typings/index.d.ts
+++ b/dist/typings/index.d.ts
@@ -6,3 +6,4 @@ export { default as useStep } from './useStep';
 export { default as useThrottle } from './useThrottle';
 export { default as useToggle } from './useToggle';
 export { default as useValidate } from './useValidate';
+export { default as useLocalStorageState } from './useLocalStorageState';

--- a/dist/typings/useLocalStorageState/index.d.ts
+++ b/dist/typings/useLocalStorageState/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './useLocalStorageState';

--- a/dist/typings/useLocalStorageState/useLocalStorageState.d.ts
+++ b/dist/typings/useLocalStorageState/useLocalStorageState.d.ts
@@ -1,0 +1,8 @@
+declare function useLocalStorageState(key: string, defaultValue?: unknown, { serialize, deserialize }?: {
+    serialize?: {
+        (value: any, replacer?: ((this: any, key: string, value: any) => any) | undefined, space?: string | number | undefined): string;
+        (value: any, replacer?: (string | number)[] | null | undefined, space?: string | number | undefined): string;
+    } | undefined;
+    deserialize?: ((text: string, reviver?: ((this: any, key: string, value: any) => any) | undefined) => any) | undefined;
+}): any[];
+export default useLocalStorageState;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flywire/react-hooks",
-  "version": "2.0.1",
+  "version": "2.3.0",
   "description": "A collection of Reacts hooks used in Flywire",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { default as useStep } from './useStep';
 export { default as useThrottle } from './useThrottle';
 export { default as useToggle } from './useToggle';
 export { default as useValidate } from './useValidate';
+export { default as useLocalStorageState } from './useLocalStorageState';

--- a/src/useLocalStorageState/README.md
+++ b/src/useLocalStorageState/README.md
@@ -1,0 +1,37 @@
+# useLocalStorageState
+
+`useLocalStorageState` is a hook for having state in a component that is synced
+to localStorage
+
+#### Usage
+
+```js
+import { useLocalStorageState } from '@flywire/react-hooks';
+
+const [state, setState] = useLocalStorageState('yourKey', 'defaultValue');
+```
+
+#### Config
+
+| Key            | Description                                                                    |
+| :------------- | :----------------------------------------------------------------------------- |
+| `key`          | Key used to save in localStorage.                                              |
+| `defaultValue` | If the record in localStorage does not exists, sets its default.               |
+| `options`      | Allows you to specify a `serialize` and `deserialize` function of your choice. |
+
+#### Example
+
+```jsx harmony
+import React from 'react';
+import { useLocalStorageState } from '@flywire/react-hooks';
+
+function App() {
+  const [on, setOn] = useLocalStorageState(`button-isOn`, true);
+
+  return <button onClick={() => setOn(!on)}>{on ? 'ON' : 'OFF'}</button>;
+}
+
+export default App;
+```
+
+[Demo](https://codesandbox.io/s/flywire-react-hooks-useonclickoutside-q5dw2?file=/src/App.js)

--- a/src/useLocalStorageState/index.ts
+++ b/src/useLocalStorageState/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useLocalStorageState';

--- a/src/useLocalStorageState/useLocalStorageState.test.tsx
+++ b/src/useLocalStorageState/useLocalStorageState.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useLocalStorageState } from '../index';
+
+afterEach(() => window.localStorage.clear());
+
+test('saves the state to localStorage on update', () => {
+  const { result } = renderHook(() => useLocalStorageState('hello', 'value'));
+  const [, setState] = result.current;
+
+  act(() => {
+    setState('another value');
+  });
+
+  expect(result.current[0]).toBe('another value');
+  expect(window.localStorage.getItem('hello')).toBe(
+    JSON.stringify('another value'),
+  );
+});
+
+describe('when a value is already present in the localStorage', () => {
+  beforeEach(() =>
+    window.localStorage.setItem('hello', JSON.stringify('stored value')),
+  );
+
+  test('returns the stored value', () => {
+    const { result } = renderHook(() => useLocalStorageState('hello'));
+    const [state] = result.current;
+
+    expect(state).toBe('stored value');
+    expect(window.localStorage.getItem('hello')).toBe(
+      JSON.stringify('stored value'),
+    );
+  });
+});
+
+describe('when  passing a function as a defaultValue', () => {
+  test('returns the value', () => {
+    const { result } = renderHook(() =>
+      useLocalStorageState('key', () => 'key value'),
+    );
+    const [state] = result.current;
+
+    expect(state).toBe('key value');
+  });
+});
+
+describe('when  passing a value as a defaultValue', () => {
+  test('returns the value', () => {
+    const { result } = renderHook(() => useLocalStorageState('key', 3));
+    const [state] = result.current;
+
+    expect(state).toBe(3);
+  });
+});
+
+describe('when deserializing causes an error', () => {
+  test('handles it and removes the element', () => {
+    JSON.stringify = jest.fn().mockImplementationOnce(() => {
+      throw new Error('Error deserializing');
+    });
+
+    renderHook(() => useLocalStorageState('key', 'key value'));
+
+    expect(window.localStorage.getItem('key')).toBe(null);
+  });
+});
+
+describe('when changing the key in runtime', () => {
+  test('deletes the item of previous key', () => {
+    const { result, rerender } = renderHook(
+      ({ key }) => useLocalStorageState(key, 'initialValue'),
+      {
+        initialProps: { key: 'key' },
+      },
+    );
+    const [, setState] = result.current;
+
+    rerender({ key: 'another key' });
+
+    act(() => {
+      setState('another value');
+    });
+
+    expect(window.localStorage.getItem('key')).toBe(null);
+    expect(result.current[0]).toBe('another value');
+  });
+});

--- a/src/useLocalStorageState/useLocalStorageState.ts
+++ b/src/useLocalStorageState/useLocalStorageState.ts
@@ -1,0 +1,34 @@
+import { useState, useRef, useEffect } from 'react';
+
+function useLocalStorageState(
+  key: string,
+  defaultValue: unknown = '',
+  { serialize = JSON.stringify, deserialize = JSON.parse } = {},
+) {
+  const [state, setState] = useState(() => {
+    const valueInLocalStorage = window.localStorage.getItem(key);
+    if (valueInLocalStorage) {
+      try {
+        return deserialize(valueInLocalStorage);
+      } catch {
+        window.localStorage.removeItem(key);
+      }
+    }
+    return typeof defaultValue === 'function' ? defaultValue() : defaultValue;
+  });
+
+  const prevKeyRef = useRef(key);
+
+  useEffect(() => {
+    const prevKey = prevKeyRef.current;
+    if (prevKey !== key) {
+      window.localStorage.removeItem(prevKey);
+    }
+    prevKeyRef.current = key;
+    window.localStorage.setItem(key, serialize(state));
+  }, [key, state, serialize]);
+
+  return [state, setState];
+}
+
+export default useLocalStorageState;


### PR DESCRIPTION
Hook extracted from the Epic React course from Kent C Dodds and used in `missioncontrol-pricing` for "remembering" the state of the sidenav menu.