### PR TITLE
Set babelHelpers to runtime

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,11 +11,11 @@ export default {
   output: [
     {
       file: pkg.main,
-      format: 'cjs'
+      format: 'cjs',
     },
     {
       file: pkg.module,
-      format: 'es'
+      format: 'es',
     },
   ],
   plugins: [
@@ -27,8 +27,9 @@ export default {
     }),
     commonjs(),
     babel({
-      babelHelpers: 'bundled',
+      extensions: ['.ts', '.tsx'],
       exclude: 'node_modules/**',
+      babelHelpers: 'runtime',
     }),
   ],
 };


### PR DESCRIPTION
babelHelpers should be set to runtime when building libraries with Rollup.
More info here https://github.com/rollup/plugins/tree/master/packages/babel#babelhelpers